### PR TITLE
Add permissions key to workflow-example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ jobs:
   rollout:
     needs: ["build_and_push"]
     runs-on: fasit-deploy
+    permissions:
+      id-token: write
     steps:
       - name: read sha
         id: sha


### PR DESCRIPTION
The action fails if the `id-token: write` permission is not set, so add it to the example.